### PR TITLE
ci: fixed distributor name of TcUnit

### DIFF
--- a/.Zeugwerk/config.json
+++ b/.Zeugwerk/config.json
@@ -13,7 +13,7 @@
             {
               "version": "1.3.0.0",
               "name": "TcUnit",
-              "distributor-name": "Jakob Sagatowski"
+              "distributor-name": "www.tcunit.org"
             }
           ],
           "references": {


### PR DESCRIPTION
Sorry, there was an issue with the 1.2.0.0 package of TcUnit, the distributor name was incorrect. For details see https://github.com/Zeugwerk/Twinpack-Registry/pull/1